### PR TITLE
Swap reset and done

### DIFF
--- a/src/main/java/btw/lowercase/optiboxes/config/OptiBoxesConfigScreen.java
+++ b/src/main/java/btw/lowercase/optiboxes/config/OptiBoxesConfigScreen.java
@@ -45,11 +45,11 @@ public class OptiBoxesConfigScreen extends Screen {
         GridLayout footerGridLayout = new GridLayout();
         footerGridLayout.defaultCellSetting().paddingHorizontal(4).paddingBottom(4).alignHorizontallyCenter();
         GridLayout.RowHelper footerRowHelper = footerGridLayout.createRowHelper(2);
-        footerRowHelper.addChild(Button.builder(CommonComponents.GUI_DONE, (button) -> this.onClose()).width(125).build());
         footerRowHelper.addChild(Button.builder(ConfigTranslate.RESET, (button) -> {
             config.reset();
             this.minecraft.reloadResourcePacks();
         }).width(125).build());
+        footerRowHelper.addChild(Button.builder(CommonComponents.GUI_DONE, (button) -> this.onClose()).width(125).build());
         layout.addToFooter(footerGridLayout);
 
         layout.visitWidgets(this::addRenderableWidget);


### PR DESCRIPTION
In most config screens of the vanilla game and mods, the done button is always on the right. Hence I was surprised to see it be the opposite here, which could cause misclicks on the reset button.

(This change was not tested by compiling the mod, but should work anyways.)