### PR TITLE
Remove spotless line ending restriction

### DIFF
--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -23,7 +23,6 @@ tasks.named("publishMods") {
 // Header
 spotless {
     val licenseHeader = rootProject.file("HEADER")
-    lineEndings = com.diffplug.spotless.LineEnding.UNIX
 
     java {
         licenseHeaderFile(licenseHeader)


### PR DESCRIPTION
This PR removes the spotless line endings restriction to UNIX. This makes the mod able to be built on Windows machines, which was unable to be done before this change because every java file of the project is encoded using Windows line endings